### PR TITLE
Dev

### DIFF
--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -21,6 +21,7 @@ class AlbumsController < ApplicationController
   end
 
   def show
+    authorize @album
     respond_with(@album)
   end
 

--- a/app/policies/album_policy.rb
+++ b/app/policies/album_policy.rb
@@ -9,6 +9,12 @@ class AlbumPolicy < ApplicationPolicy
     user && user.persisted?
   end
 
+  def show?
+    return true unless record.private?
+    return false unless user
+    user.admin? || (record.creator == user) || record.followers.include?(user)
+  end
+
   def new?
     user && user.persisted?
   end

--- a/test/controllers/albums_controller_test.rb
+++ b/test/controllers/albums_controller_test.rb
@@ -50,6 +50,66 @@ describe AlbumsController do
     end
   end
 
+  describe "GET show" do
+    describe "the card is public" do
+      before do
+        public_album.update creator: peter
+      end
+
+      it "everyone can access the page" do
+        get :show, id: public_album.id
+        assert_response :success
+      end
+    end
+
+    describe "the card is private" do
+      before do
+        private_album.update creator: peter
+      end
+
+      describe "not logged in user" do
+        it "can not access the page" do
+          get :show, id: private_album.id
+          assert_redirected_to root_path
+        end
+      end
+
+      describe "logged in as the creator" do
+        before do
+          sign_in peter
+        end
+
+        it "can access the page" do
+          get :show, id: private_album.id
+          assert_response :success
+        end
+      end
+
+      describe "logged in as the follower" do
+        before do
+          allen.joins_album private_album
+          sign_in allen
+        end
+
+        it "can access the page" do
+          get :show, id: private_album.id
+          assert_response :success
+        end
+      end
+
+      describe "logged in as the other user" do
+        before do
+          sign_in allen
+        end
+
+        it "can access the page" do
+          get :show, id: private_album.id
+          assert_redirected_to root_path
+        end
+      end
+    end
+  end
+
   describe "POST create album" do
     describe "not logged in" do
       it "can not access the page" do


### PR DESCRIPTION
change log:
fixed:
- authorize for private card show page. Only Admin, creator, and the card's followers can access the page
